### PR TITLE
Container placement check plate

### DIFF
--- a/container/update_container_placements.py
+++ b/container/update_container_placements.py
@@ -78,7 +78,8 @@ def read_layout(layout_file):
 
             # if plate_id is missing, give an error message
             if not plate_id:
-                raise RuntimeError("Plate ID is missing in the scanner output file! The plate may have been turned around and scanned the wrong way.")
+                print("ERROR: No plate ID (RackCode) in the uploaded file. The plate was probably turned around and scanned in the wrong way.")
+                sys.exit(1)
 
             # if not 2D tube, sample(TubeID) is empty
             if sample:

--- a/container/update_container_placements.py
+++ b/container/update_container_placements.py
@@ -76,6 +76,10 @@ def read_layout(layout_file):
                 well = parts[0]
                 sample = parts[1]
 
+            # if plate_id is missing, give an error message
+            if not plate_id:
+                raise RuntimeError("Plate ID is missing in the scanner output file! The plate may have been turned around and scanned the wrong way.")
+
             # if not 2D tube, sample(TubeID) is empty
             if sample:
                 well = format_well(well)


### PR DESCRIPTION
Diag lab wants to get an error when the uploaded scanner output file has no plate ID which indicates that the plate was turned around not scanned in the correct way. 